### PR TITLE
Add AssemblyAIAudioToTextService.cs

### DIFF
--- a/src/AssemblyAI.SemanticKernel/AssemblyAI.SemanticKernel.csproj
+++ b/src/AssemblyAI.SemanticKernel/AssemblyAI.SemanticKernel.csproj
@@ -1,49 +1,55 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>AssemblyAI.SemanticKernel</RootNamespace>
-    <AssemblyName>AssemblyAI.SemanticKernel</AssemblyName>
-    <PackageId>AssemblyAI.SemanticKernel</PackageId>
-    <Title>AssemblyAI plugins for Semantic Kernel</Title>
-    <Authors>AssemblyAI</Authors>
-    <Description>Transcribe audio using AssemblyAI with Semantic Kernel plugins</Description>
-    <Copyright>Copyright 2023 (c) AssemblyAI, Inc. All rights reserved.</Copyright>
-    <PackageTags>SemanticKernel;AI;AssemblyAI;transcript</PackageTags>
-    <Company>AssemblyAI</Company>
-    <Product>AssemblyAI</Product>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
-    <PackageVersion>1.0.3</PackageVersion>
-    <OutputType>Library</OutputType>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/AssemblyAI/assemblyai-semantic-kernel</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/AssemblyAI/assemblyai-semantic-kernel.git</RepositoryUrl>
-    <PackageIconUrl>https://www.assemblyai.com/favicon.png</PackageIconUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <RepositoryType>git</RepositoryType>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(CI)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Net.Http.Json">
-      <Version>8.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>AssemblyAI.SemanticKernel</RootNamespace>
+        <AssemblyName>AssemblyAI.SemanticKernel</AssemblyName>
+        <PackageId>AssemblyAI.SemanticKernel</PackageId>
+        <Title>AssemblyAI plugins for Semantic Kernel</Title>
+        <Authors>AssemblyAI</Authors>
+        <Description>Transcribe audio using AssemblyAI with Semantic Kernel plugins</Description>
+        <Copyright>Copyright 2023 (c) AssemblyAI, Inc. All rights reserved.</Copyright>
+        <PackageTags>SemanticKernel;AI;AssemblyAI;transcript</PackageTags>
+        <Company>AssemblyAI</Company>
+        <Product>AssemblyAI</Product>
+        <AssemblyVersion>1.0.3.0</AssemblyVersion>
+        <FileVersion>1.0.3.0</FileVersion>
+        <PackageVersion>1.0.3</PackageVersion>
+        <OutputType>Library</OutputType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/AssemblyAI/assemblyai-semantic-kernel</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/AssemblyAI/assemblyai-semantic-kernel.git</RepositoryUrl>
+        <PackageIconUrl>https://www.assemblyai.com/favicon.png</PackageIconUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <RepositoryType>git</RepositoryType>
+        <NoWarn>SKEXP0005</NoWarn>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(CI)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SemanticKernel">
+            <Version>1.4.0</Version>
+        </PackageReference>
+        <PackageReference Include="System.Net.Http.Json">
+            <Version>8.0.0</Version>
+        </PackageReference>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Reference Include="AssemblyAI">
+            <HintPath>..\..\..\assemblyai-csharp-sdk\src\AssemblyAI\bin\Debug\netstandard2.0\AssemblyAI.dll</HintPath>
+        </Reference>
+    </ItemGroup>
 </Project>

--- a/src/AssemblyAI.SemanticKernel/AssemblyAI.SemanticKernel.csproj
+++ b/src/AssemblyAI.SemanticKernel/AssemblyAI.SemanticKernel.csproj
@@ -11,9 +11,9 @@
         <PackageTags>SemanticKernel;AI;AssemblyAI;transcript</PackageTags>
         <Company>AssemblyAI</Company>
         <Product>AssemblyAI</Product>
-        <AssemblyVersion>1.1.0.0</AssemblyVersion>
-        <FileVersion>1.1.0.0</FileVersion>
-        <PackageVersion>1.1.0</PackageVersion>
+        <AssemblyVersion>1.2.0.0</AssemblyVersion>
+        <FileVersion>1.2.0.0</FileVersion>
+        <PackageVersion>1.2.0</PackageVersion>
         <OutputType>Library</OutputType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/AssemblyAI/assemblyai-semantic-kernel</PackageProjectUrl>
@@ -33,13 +33,13 @@
     </PropertyGroup>
     <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options">
-        <Version>8.0.0</Version>
+        <Version>8.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
         <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.SemanticKernel">
-        <Version>1.0.1</Version>
+        <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http.Json">
         <Version>8.0.0</Version>

--- a/src/AssemblyAI.SemanticKernel/AssemblyAIAudioToTextExecutionSettings.cs
+++ b/src/AssemblyAI.SemanticKernel/AssemblyAIAudioToTextExecutionSettings.cs
@@ -1,0 +1,15 @@
+using Microsoft.SemanticKernel;
+
+namespace AssemblyAI.SemanticKernel
+{
+    /// <summary>
+    /// Configure AssemblyAI transcript parameters
+    /// </summary>
+    public class AssemblyAIAudioToTextExecutionSettings : PromptExecutionSettings
+    {
+        /// <summary>
+        /// Parameters to transcribe audio using AssemblyAI.
+        /// </summary>
+        public CreateTranscriptOptionalParameters TranscriptParameters { get; set; }
+    }
+}

--- a/src/AssemblyAI.SemanticKernel/AssemblyAIAudioToTextService.cs
+++ b/src/AssemblyAI.SemanticKernel/AssemblyAIAudioToTextService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AssemblyAI.Transcripts;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.AudioToText;
+using Microsoft.SemanticKernel.Contents;
+
+namespace AssemblyAI.SemanticKernel
+{
+    /// <summary>
+    /// AssemblyAI speech-to-text service.
+    /// </summary>
+    public class AssemblyAIAudioToTextService : IAudioToTextService
+    {
+        private readonly AssemblyAIClient _client;
+
+        /// <summary>
+        /// Attributes are not used by AssemblyAIAudioToTextService.
+        /// </summary>
+        public IReadOnlyDictionary<string, object> Attributes => new Dictionary<string, object>();
+
+        /// <summary>
+        /// Creates an instance of the <see cref="AssemblyAIAudioToTextService"/> with an AssemblyAI API key.
+        /// </summary>
+        /// <param name="apiKey">OpenAI API Key</param>
+        public AssemblyAIAudioToTextService(string apiKey)
+        {
+            _client = new AssemblyAIClient(apiKey);
+        }
+
+        /// <inheritdoc/>
+        public async Task<TextContent> GetTextContentAsync(
+            AudioContent content,
+            PromptExecutionSettings executionSettings = null,
+            Kernel kernel = null,
+            CancellationToken cancellationToken = default)
+        {
+            UploadedFile uploadedFile;
+            using (var stream = content.Data.ToStream())
+            {
+                uploadedFile = await _client.Files.Upload(stream).ConfigureAwait(false);
+            }
+
+            AssemblyAI.Transcript transcript;
+            if (executionSettings != null && executionSettings is AssemblyAIAudioToTextExecutionSettings aaiSettings)
+            {
+                if (aaiSettings.TranscriptParameters == null)
+                {
+                    throw new Exception(
+                        "AssemblyAIAudioToTextExecutionSettings.TranscriptParameters is required when passing execution settings.");
+                }
+
+                transcript = await _client.Transcripts.Create(
+                    uploadedFile.UploadUrl,
+                    aaiSettings.TranscriptParameters
+                ).ConfigureAwait(false);
+            }
+            else
+            {
+                transcript = await _client.Transcripts.Create(new CreateTranscriptParameters
+                {
+                    AudioUrl = uploadedFile.UploadUrl
+                }).ConfigureAwait(false);
+            }
+
+            return new TextContent(
+                text: transcript.Text,
+                modelId: null,
+                innerContent: transcript,
+                encoding: Encoding.UTF8,
+                metadata: null
+            );
+        }
+    }
+}

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -34,10 +34,10 @@
       <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.SemanticKernel">
-      <Version>1.0.1</Version>
+      <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.SemanticKernel.Planners.Handlebars">
-      <Version>1.0.1-preview</Version>
+      <Version>1.4.0-preview</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add `AssemblyAIAudioToTextService`

This PR is in draft because it relies on my locally compiled .NET SDK for AAI which hasn't been released yet.

Todo:
- Add sample for using AssemblyAIAudioToTextService